### PR TITLE
windows: Windows test harness (CTest ovntest + autotest Surface III)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,12 @@ list(FILTER OVN_CONTROLLER_SRC EXCLUDE REGEX
 add_executable(ovn-controller ${OVN_CONTROLLER_SRC})
 ovn_exe(ovn-controller)
 
+# Same controller sources minus main(), reused by ovntest so the controller
+# test drivers (test-lflow-cache, test-vif-plug) link against the identical
+# object set that ovn-controller links (guaranteed symbol resolution).
+set(OVN_CONTROLLER_TESTOBJ ${OVN_CONTROLLER_SRC})
+list(FILTER OVN_CONTROLLER_TESTOBJ EXCLUDE REGEX "/ovn-controller\\.c$")
+
 # ovn-northd: all of northd/ is portable; only the test driver is excluded.
 file(GLOB OVN_NORTHD_SRC CONFIGURE_DEPENDS "${OVN_ROOT}/northd/*.c")
 list(FILTER OVN_NORTHD_SRC EXCLUDE REGEX "/test-ipam\\.c$")
@@ -206,10 +212,10 @@ install(FILES "${OVS_ROOT}/vswitchd/vswitch.ovsschema"
 # clashing with the OVS subproject's own ovstest target.  The autotools autotest
 # suite (tests/*.at -> tests/testsuite) is not used on Windows.
 #
-# Only libovn-level modules are included.  The controller/northd test drivers
-# (controller/test-lflow-cache.c, controller/test-vif-plug.c, northd/test-ipam.c)
-# and the netlink test (tests/test-ovn-netlink.c, HAVE_NETLINK/Linux only) need
-# extra controller/northd objects or Linux netlink and are left out for now.
+# libovn-level modules plus the controller/northd test drivers, which link the
+# same controller sources as ovn-controller (OVN_CONTROLLER_TESTOBJ) plus
+# northd/ipam.c.  The netlink test (tests/test-ovn-netlink.c) stays out
+# (HAVE_NETLINK/Linux only).
 set(OVNTEST_SOURCES
   tests/ovstest.c
   tests/test-utils.c
@@ -218,8 +224,12 @@ set(OVNTEST_SOURCES
   tests/test-vector.c
   lib/test-lflow-conj-ids.c
   lib/test-ovn-features.c
-  lib/test-ofctrl-seqno.c)
-add_executable(ovntest ${OVNTEST_SOURCES})
+  lib/test-ofctrl-seqno.c
+  controller/test-lflow-cache.c
+  controller/test-vif-plug.c
+  northd/test-ipam.c
+  northd/ipam.c)
+add_executable(ovntest ${OVNTEST_SOURCES} ${OVN_CONTROLLER_TESTOBJ})
 ovn_exe(ovntest)
 
 # Configure-time drift guard: FATAL if an upstream-added tests/test-*.c registers

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -66,6 +66,7 @@
 /testsuite
 /testsuite.dir/
 /testsuite.log
+/package.m4
 /test-lib
 /testsuite.tmp.orig
 /valgrind.[0-9]*

--- a/tests/windows-testsuite.at
+++ b/tests/windows-testsuite.at
@@ -1,0 +1,47 @@
+AT_INIT
+
+m4_ifdef([AT_COLOR_TESTS], [AT_COLOR_TESTS])
+
+dnl ===========================================================================
+dnl  dbosoft OVN -- Windows autotest suite: the FULL upstream test set with the
+dnl  Windows harness shims layered in.  m4_includes UNCHANGED upstream .at bodies
+dnl  (resync cost 0) plus tests/windows/windows-shell-helpers.at (pwd -W so the
+dnl  native daemons resolve punix:$OVS_RUNDIR/... sockets).
+dnl
+dnl  Ordered userspace/logic-first (no real datapath needed -> likely to pass on
+dnl  Windows), with the datapath/integration-heavy suites (ovn.at, ovn-controller,
+dnl  ovn-ic, ipsec) LAST, so a -j1 sweep yields a meaningful pass count early.
+dnl  Run -j1; curate down via excluded-*.txt once the pass/fail map is known.
+dnl ===========================================================================
+
+m4_include([tests/ovs-macros.at])
+m4_include([tests/ovsdb-macros.at])
+m4_include([tests/ofproto-macros.at])
+m4_include([tests/ovn-macros.at])
+m4_include([tests/windows/windows-shell-helpers.at])
+m4_include([tests/network-functions.at])
+
+dnl ---- userspace / control-plane logic (no real datapath) ----
+m4_include([tests/ovn-features.at])
+m4_include([tests/ovn-lflow-cache.at])
+m4_include([tests/ovn-lflow-conj-ids.at])
+m4_include([tests/ovn-ofctrl-seqno.at])
+m4_include([tests/ovn-util.at])
+m4_include([tests/ovn-ipam.at])
+m4_include([tests/ovn-nbctl.at])
+m4_include([tests/ovn-sbctl.at])
+m4_include([tests/ovn-ic-nbctl.at])
+m4_include([tests/ovn-ic-sbctl.at])
+m4_include([tests/ovn-northd.at])
+m4_include([tests/ovn-inc-proc-graph-dump.at])
+m4_include([tests/ovn-br-controller.at])
+m4_include([tests/ovn-vif-plug.at])
+m4_include([tests/checkpatch.at])
+
+dnl ---- datapath / integration heavy (likely to need a real datapath) ----
+m4_include([tests/ovn.at])
+m4_include([tests/ovn-performance.at])
+m4_include([tests/ovn-controller.at])
+m4_include([tests/ovn-controller-vtep.at])
+m4_include([tests/ovn-ic.at])
+m4_include([tests/ovn-ipsec.at])

--- a/tests/windows/excluded-keywords.txt
+++ b/tests/windows/excluded-keywords.txt
@@ -1,0 +1,7 @@
+# autotest KEYWORDS whose tests are skipped on Windows because they exercise a
+# feature with no Windows support.  Keep this minimal -- everything else must run
+# and be fixed, not skipped.
+#
+#   python - the OVS/OVN Python bindings have no Windows support (a separate
+#            track); the "- Python3" test variants exercise those bindings.
+python

--- a/tests/windows/excluded-tests.txt
+++ b/tests/windows/excluded-tests.txt
@@ -1,0 +1,28 @@
+# Test GROUP TITLES (matched as a substring) skipped on Windows because the
+# FEATURE or TEST METHOD is genuinely not available there -- NOT because of an
+# OVN build bug.  REAL build bugs (see known-failures.md: the xxreg/xreg register
+# field-width bug and the ovn-nbctl mirror Index/Key integer bug) are
+# deliberately NOT listed here: they must run and FAIL until fixed.
+#
+# This list is curated from an observed run (tests/windows/baseline) and is meant
+# to grow only with method/feature incompatibilities, never to paper over bugs.
+
+# ovn-ic-nbctl / ovn-ic-sbctl (and ovn-ic) are not built by the CMake overlay
+# yet, so these tests fail with "command not found".  Re-enable once the ic
+# binaries are added to CMakeLists.txt.
+ovn-ic-nbctl
+ovn-ic-sbctl
+
+# These pause and resume ovn-northd with `kill -STOP` / `kill -CONT`
+# (SIGSTOP/SIGCONT) to drive incremental processing.  Windows has no
+# SIGSTOP/SIGCONT and the taskkill-based kill shim can only terminate a process,
+# so the pause/resume step exits non-zero and the test cannot run as written.
+Load balancer incremental processing - batched updates
+Added and Deleted Logical Switch
+LS/LSP add and delete
+ipam router ports - incremental processing
+port group segfault
+
+# Asserts a POSIX signal exit code (142 = 128 + SIGALRM) that Windows does not
+# produce (the daemon exits via WaitForMultipleObjects deadline instead).
+test unixctl

--- a/tests/windows/known-failures.md
+++ b/tests/windows/known-failures.md
@@ -1,0 +1,51 @@
+# OVN Windows test suite — known failures (real build bugs)
+
+These are **real OVN/MSVC build bugs** surfaced by the Windows autotest suite
+(`tests/windows/run-windows-testsuite.ps1`). They are deliberately **not** in
+`excluded-tests.txt`: the tests must keep running and failing until the bugs are
+fixed. Method/feature incompatibilities (which *are* excluded) live in
+`excluded-tests.txt` / `excluded-keywords.txt`.
+
+Baseline run: userspace groups 1–371, **304 pass / 65 fail / 2 skip** (after the
+PKI + watchdog fixes; before excluding the method-incompatible tests).
+
+## 1. `xxreg`/`xreg` register field width is wrong on MSVC  ⚠️ fix soon
+
+The single biggest cause (~16 direct failures, plus likely cascades into the
+`ovn-macros.at:992`/`:944` "NBDB→SBDB" convergence checks). Every test that uses
+an `xreg`/`xxreg` subfield in a flow logs:
+
+```
+expr|WARN|xxreg0[64..127]: error parsing xreg0 subfield
+  (Cannot select bits 64 to 127 of 2-bit field xxreg0.)
+expr|WARN|xxreg1[0..63]:  error parsing xreg3 subfield
+  (Cannot select bits 0 to 63 of 8-bit field xxreg1.)
+```
+
+`xxreg0` is a **128-bit** register and `xreg*` are **64-bit**, but the build
+reports them as **2-bit / 8-bit**, so the expr parser rejects every `xreg`/`xxreg`
+subfield reference and northd flow generation breaks. The symbols are registered
+in `lib/logical-fields.c` (`expr_symtab_add_field(symtab, xxname, MFF_XXREG0 + xxi, ...)`)
+from the OVS `mf_fields[]` meta-flow table — the wrong width points at an
+enum/array-index or struct-width miscomputation of `MFF_XXREG*`/`MFF_XREG*` on
+MSVC. Same integer-handling family as bug #2.
+
+## 2. `ovn-nbctl` mirror `Index/Key` integer bug
+
+`ovn-nbctl.at:493` (mirrors, direct + daemon). `mirror-list` prints:
+
+```
+Index/Key:  -4294967296      (expected 0)
+Index/Key:  -4294967295      (expected 1)
+```
+
+`-4294967296 = 0xFFFFFFFF00000000`: a 32-bit mirror index sign-extended into the
+high 32 bits of a 64-bit value when read from the OVSDB integer column / printed.
+MSVC integer-width/sign-extension bug.
+
+## Still to triage
+
+~37 failures (mostly `ovn-macros.at:992`/`:944` and `ovs-macros.at:221` macro
+"hard failure"s) are not yet individually root-caused. Most are expected to be
+downstream of bug #1 (northd producing wrong/incomplete southbound data); they
+should be re-checked once the `xxreg` width bug is fixed.

--- a/tests/windows/run-windows-testsuite.ps1
+++ b/tests/windows/run-windows-testsuite.ps1
@@ -1,0 +1,156 @@
+<#
+.SYNOPSIS
+  Run the OVN Windows autotest suite (tests/windows-testsuite.at) against the
+  CMake/MSVC-built binaries, under MSYS2 -- no full autotools build.
+
+.DESCRIPTION
+  dbosoft OVN counterpart of ovs/tests/windows/run-windows-testsuite.ps1.
+  Self-contained: it does everything the suite needs so nothing has to be set up
+  by hand (that is how "missing test PKI" silently broke runs before):
+    1. alias the CMake `ovntest` as `ovstest` (the name the .at bodies invoke);
+    2. autom4te-generate tests/testsuite from the manifest + write tests/package.m4;
+    3. repoint tests/atconfig's abs_* paths at THIS checkout;
+    4. GENERATE THE TEST PKI (ovs-pki: the testpki-*.pem the ssl/tls tests need) --
+       idempotent, skipped if tests/testpki-cacert.pem already exists;
+    5. run the suite -j1 with AUTOTEST_PATH pointed at the CMake Release dirs;
+    6. a stall-watchdog reaps ONLY this run's daemons when the suite wedges, so a
+       single hung test can't block -j1 (progress = newest mtime under
+       tests/testsuite.dir; the at-groups dir number is NOT a valid progress
+       signal -- autotest pre-creates the range endpoint).
+
+  eryph-zero managed OVN/OVS services (started before this run) are never touched:
+  the watchdog only kills processes whose StartTime >= the run start.
+
+.EXAMPLE
+  .\run-windows-testsuite.ps1                       # whole suite
+  .\run-windows-testsuite.ps1 -Groups '1-371'       # a range
+  .\run-windows-testsuite.ps1 -List                 # just list groups
+#>
+[CmdletBinding()]
+param(
+  [string]$BuildDir   = 'F:\source\repos\dbosoft\ovn\build-cmake',
+  [string]$Groups     = '',                       # autotest selector, e.g. '1-371' or '1 2 3'
+  [int]$StallSeconds  = 90,                        # reap if testsuite.dir is quiet this long
+  [string]$Msys2      = 'C:\msys64',
+  [string]$OpenSslDir = 'C:\OpenSSL-Win64',
+  [string]$PthreadsBin= 'C:\PTHREADS-BUILT\bin',
+  [switch]$List
+)
+$ErrorActionPreference = 'Stop'
+$repo = (Resolve-Path "$PSScriptRoot\..\..").Path
+$bash = Join-Path $Msys2 'usr\bin\bash.exe'
+$rel  = Join-Path $BuildDir 'Release'
+$ovsrel = Join-Path $BuildDir 'ovs\Release'
+if (-not (Test-Path (Join-Path $rel 'ovntest.exe'))) { throw "ovntest.exe not under $rel -- build first." }
+if (-not (Test-Path $bash)) { throw "MSYS2 bash not found at $bash" }
+
+# CN list mirrors tests/automake.mk TESTPKI_CNS.
+$cns = 'test test2 main hv hv-foo hv1 hv2 hv3 hv4 hv5 hv6 hv7 hv8 hv9 hv10 hv-1 hv-2 hv-10-1 hv-10-2 hv-20-1 hv-20-2 vtep hv_gw pbr-hv gw1 gw2 gw3 gw4 gw5 ext1'
+
+function To-Msys([string]$p) { '/' + $p.Substring(0,1).ToLower() + ($p.Substring(2) -replace '\\','/') }
+$repoM = To-Msys $repo
+$opensslBin = To-Msys (Join-Path $OpenSslDir 'bin')
+
+# --- setup (suite + atconfig + PKI) done in one MSYS bash pass -------------
+$setup = @"
+set -e
+cd '$repoM'
+[ -e build-cmake/Release/ovstest.exe ] || cp build-cmake/Release/ovntest.exe build-cmake/Release/ovstest.exe
+cat > tests/package.m4 <<EOF
+m4_define([AT_PACKAGE_NAME],[ovn])
+m4_define([AT_PACKAGE_TARNAME],[ovn])
+m4_define([AT_PACKAGE_VERSION],[26.03.90])
+m4_define([AT_PACKAGE_STRING],[ovn 26.03.90])
+m4_define([AT_PACKAGE_BUGREPORT],[bugs@openvswitch.org])
+m4_define([AT_PACKAGE_URL],[])
+EOF
+autom4te --language=autotest -I . -o tests/testsuite tests/windows-testsuite.at
+chmod +x tests/testsuite
+sed -i -E "s#^(abs_top_srcdir=).*#\1'$repoM'#; s#^(abs_top_builddir=).*#\1'$repoM'#; s#^(abs_srcdir=).*#\1'$repoM/tests'#; s#^(abs_builddir=).*#\1'$repoM/tests'#" tests/atconfig
+# Test PKI (idempotent): generate testpki-*.pem the ssl/tls tests need.
+if [ ! -e tests/testpki-cacert.pem ]; then
+    export PATH='$opensslBin':"`$PATH"
+    PKI="sh $repoM/ovs/utilities/ovs-pki.in --dir=$repoM/tests/pki --log=$repoM/tests/ovs-pki.log"
+    rm -rf tests/pki
+    `$PKI init
+    ( cd tests/pki && for cn in $cns; do `$PKI -u req+sign `$cn || exit 1; done )
+    cp tests/pki/switchca/cacert.pem tests/testpki-cacert.pem
+    for cn in $cns; do
+        cp tests/pki/`$cn-cert.pem    tests/testpki-`$cn-cert.pem
+        cp tests/pki/`$cn-privkey.pem tests/testpki-`$cn-privkey.pem
+        cp tests/pki/`$cn-req.pem     tests/testpki-`$cn-req.pem
+    done
+    echo "PKI generated."
+else
+    echo "PKI present, skipping."
+fi
+"@
+Write-Host "[setup] generating suite + PKI ..."
+& $bash -lc $setup
+if ($LASTEXITCODE -ne 0) { throw "setup failed (rc=$LASTEXITCODE)" }
+
+$ap = "$(To-Msys $rel):$(To-Msys $ovsrel):$(To-Msys $PthreadsBin):$(To-Msys $OpenSslDir):$repoM/tests"
+$py = (Get-Command python3 -EA SilentlyContinue); if ($py) { $ap += ':' + (To-Msys (Split-Path $py.Source)) }
+
+if ($List) { & $bash -lc "cd '$repoM' && sh tests/testsuite -C tests -l"; return }
+
+# --- compute run set = candidates minus excluded-tests / excluded-keywords --
+# Method/feature-incompatible tests are skipped here (NOT real bugs); see
+# excluded-tests.txt / excluded-keywords.txt and known-failures.md.
+$exclTitle = @(); if (Test-Path "$PSScriptRoot\excluded-tests.txt")    { $exclTitle = Get-Content "$PSScriptRoot\excluded-tests.txt"    | ForEach-Object { ($_ -replace '#.*','').Trim() } | Where-Object { $_ } }
+$exclKw    = @(); if (Test-Path "$PSScriptRoot\excluded-keywords.txt") { $exclKw    = Get-Content "$PSScriptRoot\excluded-keywords.txt" | ForEach-Object { ($_ -replace '#.*','').Trim() } | Where-Object { $_ } }
+$listing = & $bash -lc "cd '$repoM' && sh tests/testsuite -C tests -l"
+$tests = @(); $cur = $null
+foreach ($ln in $listing) {
+  if ($ln -match '^\s*(\d+):\s+[\w.\-]+\.at:\d+\s+(.*?)\s*$') {
+    if ($cur) { $tests += $cur }; $cur = [pscustomobject]@{ num=[int]$Matches[1]; title=$Matches[2]; kws='' }
+  } elseif ($cur) { $cur.kws = ($cur.kws + ' ' + $ln.Trim()).Trim() }
+}
+if ($cur) { $tests += $cur }
+$lo=0;$hi=0;$explicit=$null
+if ($Groups -match '^\s*(\d+)\s*-\s*(\d+)\s*$') { $lo=[int]$Matches[1]; $hi=[int]$Matches[2] }
+elseif ($Groups.Trim()) { $explicit = @($Groups -split '\s+' | ForEach-Object {[int]$_}) }
+$run = New-Object System.Collections.Generic.List[int]; $skipped = 0
+foreach ($t in $tests) {
+  if ($lo -and ($t.num -lt $lo -or $t.num -gt $hi)) { continue }
+  if ($explicit -and ($t.num -notin $explicit)) { continue }
+  $ex = $false
+  foreach ($p in $exclTitle) { if ($t.title -like "*$p*") { $ex = $true; break } }
+  if (-not $ex) { $kw = $t.kws -split '\s+'; foreach ($k in $exclKw) { if ($kw -contains $k) { $ex = $true; break } } }
+  if ($ex) { $skipped++ } else { $run.Add($t.num) }
+}
+Write-Host ("[run] {0} groups; skipping {1} method/feature-incompatible (excluded-*.txt)" -f $run.Count, $skipped)
+$sel = ($run -join ' ')
+
+# --- run with stall-watchdog ----------------------------------------------
+$out = Join-Path $BuildDir 'winsuite.out'
+$tdir = Join-Path $repo 'tests\testsuite.dir'
+$runStart = Get-Date
+$runScript = Join-Path $BuildDir 'winsuite_inner.sh'
+$inner = "cd '$repoM' && sh tests/testsuite -C tests AUTOTEST_PATH='$ap' $sel -j1; echo RANGE_EXIT=`$? "
+[IO.File]::WriteAllText($runScript, ($inner -replace "`r",""), (New-Object Text.UTF8Encoding($false)))
+$p = Start-Process $bash -ArgumentList @('-l', (To-Msys $runScript)) -PassThru -WindowStyle Hidden -RedirectStandardOutput $out -RedirectStandardError "$out.err"
+
+function Reap { Get-Process ovsdb-server,ovs-vswitchd,ovn-northd,ovn-controller,ovn-nbctl,ovn-sbctl,ovn-ic,ovn-trace,ovn-appctl,ovn-controller-vtep -EA SilentlyContinue | Where-Object { $_.StartTime -ge $runStart } | Stop-Process -Force -EA SilentlyContinue }
+
+$lastMtime = Get-Date; $reaps = 0
+while (-not $p.HasExited) {
+  Start-Sleep 15
+  $newest = $null
+  if (Test-Path $tdir) { $newest = (Get-ChildItem $tdir -Recurse -File -EA SilentlyContinue | Sort-Object LastWriteTime | Select-Object -Last 1).LastWriteTime }
+  if ($newest -and $newest -gt $lastMtime) { $lastMtime = $newest }
+  if (((Get-Date) - $lastMtime).TotalSeconds -gt $StallSeconds) {
+    Reap; $reaps++; $lastMtime = Get-Date
+    Write-Host ("[watchdog] stall -> reaped this run's daemons (reap #{0}) at {1}" -f $reaps, (Get-Date -Format HH:mm:ss))
+  }
+}
+Start-Sleep 2; Reap
+
+# --- tally ------------------------------------------------------------------
+$o = @(Get-Content $out -EA SilentlyContinue)
+$ok   = @($o | Select-String -Pattern '^\s*\d+:.*\bok\s*$').Count
+$fail = @($o | Select-String -Pattern 'FAILED \(').Count
+$skip = @($o | Select-String -Pattern '\bskipped \(').Count
+Write-Host ("`n==== DONE reaps={0} ok={1} FAILED={2} skipped={3} ====" -f $reaps,$ok,$fail,$skip)
+$o | Select-String -Pattern 'were run|successful|behaved as expected|failed unexpectedly|RANGE_EXIT' | ForEach-Object { $_.Line.Trim() }
+$o | Select-String -Pattern 'FAILED \(' | ForEach-Object { $_.Line.Trim() }

--- a/tests/windows/windows-shell-helpers.at
+++ b/tests/windows/windows-shell-helpers.at
@@ -1,0 +1,66 @@
+dnl -*- autotest -*-
+dnl Windows test-harness shell shims for the dbosoft OVN Windows build-smoke suite.
+dnl
+dnl Mirrors ovs/tests/windows/windows-shell-helpers.at.  Keeps the upstream
+dnl tests/*.at bodies (and ovs-macros.at / ovn-macros.at / atlocal.in) UNCHANGED
+dnl -- resync cost on them stays 0.  tests/windows-testsuite.at m4_includes this
+dnl file once, after the macro libraries.
+dnl
+dnl They MUST go in the PREPARE_TESTS diversion (same as ovs-macros.at's own
+dnl helpers): ovs_init() there does `ovs_base=\`pwd\``, and OVS_RUNDIR/OVS_*DIR are
+dnl derived from it.  The pwd() shim below rewrites that to a Windows path (pwd -W)
+dnl so the native ovsdb-server.exe/ovn-northd.exe etc. can resolve
+dnl punix:$OVS_RUNDIR/... sockets and pidfiles.  At top level the shim would be
+dnl defined too late (wrong diversion) and ovs_init would capture an MSYS /c/...
+dnl path the native binaries reject with "listen failed: No such file or directory".
+m4_divert_push([PREPARE_TESTS])
+[
+# Detect Windows via the MSYS2-set $MSYSTEM (MSYS / MINGW64 / UCRT64 / ...), which
+# is reliable across MSYS2 flavors and versions.  `uname` / $MACHTYPE is NOT: modern
+# MSYS2 reports x86_64-pc-cygwin and uname strings vary by subsystem (see swig/cccl#20),
+# so the historical `case \`uname\` in MINGW*|MSYS*` check misfires.
+if test -n "$MSYSTEM"; then
+    IS_WIN32=yes
+else
+    IS_WIN32=no
+fi
+
+if test "$IS_WIN32" = "yes"; then
+    pwd () {
+        command pwd -W "$@"
+    }
+
+    diff () {
+        command diff --strip-trailing-cr "$@"
+    }
+
+    # tskill is more effective than taskkill but it isn't always installed.
+    if (tskill //?) >/dev/null 2>&1; then :; else
+        tskill () { taskkill //F //PID $1 >/dev/null; }
+    fi
+
+    kill () {
+        signal=
+        retval=0
+        for arg; do
+            arg=$(echo $arg | tr -d '\n\r')
+            case $arg in
+            -*) signal=$arg ;;
+            [1-9][0-9]*)
+                # tasklist always returns 0.
+                # If pid does exist, there will be a line with the pid.
+                if tasklist //fi "PID eq $arg" | grep $arg >/dev/null; then
+                    if test "X$signal" != "X-0"; then
+                        tskill $arg
+                    fi
+                else
+                    retval=1
+                fi
+                ;;
+            esac
+        done
+        return $retval
+    }
+fi
+]
+m4_divert_pop([PREPARE_TESTS])


### PR DESCRIPTION
Adds the Windows test infrastructure on top of the 26.03 resync (now in `dbosoft-main`). Delta only — no upstream churn.

## ovntest (CTest unit net)
`ovntest` now also links the controller/northd test modules (test-lflow-cache / test-vif-plug / test-ipam) by reusing ovn-controller's own sources, recovering the lflow-cache/ipam/vif-plug unit tests that previously failed with "ovstest: unknown command".

## autotest "Surface III" runner
`tests/windows/run-windows-testsuite.ps1` runs OVN's `.at` suite against the CMake/MSVC binaries with no full autotools build: generates the suite, repoints atconfig, **generates the test PKI** (baked in so it can't silently break runs), runs `-j1` with a stall-watchdog that reaps only the run's own daemons (eryph-zero services untouched), and applies the exclusion lists.
- `tests/windows-testsuite.at` — m4_include manifest over unchanged upstream `.at` bodies.
- `tests/windows/windows-shell-helpers.at` — `pwd -W`/CRLF/taskkill shims so native daemons resolve `punix:$OVS_RUNDIR` sockets.
- `excluded-tests.txt`/`excluded-keywords.txt` — method/feature-incompatible tests skipped (ic binaries not built yet; SIGSTOP/SIGCONT incremental-processing; POSIX signal-exit; python bindings).
- `known-failures.md` — real MSVC build bugs the suite found (deliberately **not** excluded; must run and fail until fixed): xxreg/xreg register field width; ovn-nbctl mirror Index/Key integer.

Baseline userspace run (groups 1-371): **304 pass / 65 fail / 2 skip**. Datapath half (372-1215) not yet baselined.