### PR TITLE
tests/windows: correct the xxreg known-failure diagnosis

### DIFF
--- a/tests/windows/known-failures.md
+++ b/tests/windows/known-failures.md
@@ -7,28 +7,41 @@ fixed. Method/feature incompatibilities (which *are* excluded) live in
 `excluded-tests.txt` / `excluded-keywords.txt`.
 
 Baseline run: userspace groups 1–371, **304 pass / 65 fail / 2 skip** (after the
-PKI + watchdog fixes; before excluding the method-incompatible tests).
+PKI + watchdog fixes; before excluding the method-incompatible tests). **NOTE:**
+that local baseline was contaminated by bug #1 below (a stale generated `.inc`
+in the local tree), which inflated the failure count; it must be re-measured on
+a clean build.
 
-## 1. `xxreg`/`xreg` register field width is wrong on MSVC  ⚠️ fix soon
+## 1. `xxreg`/`xreg` register field width wrong — RESOLVED (stale generated `.inc`, not an MSVC bug)
 
-The single biggest cause (~16 direct failures, plus likely cascades into the
-`ovn-macros.at:992`/`:944` "NBDB→SBDB" convergence checks). Every test that uses
-an `xreg`/`xxreg` subfield in a flow logs:
+The symptom: every test using an `xreg`/`xxreg` subfield logged
 
 ```
 expr|WARN|xxreg0[64..127]: error parsing xreg0 subfield
   (Cannot select bits 64 to 127 of 2-bit field xxreg0.)
-expr|WARN|xxreg1[0..63]:  error parsing xreg3 subfield
-  (Cannot select bits 0 to 63 of 8-bit field xxreg1.)
 ```
 
-`xxreg0` is a **128-bit** register and `xreg*` are **64-bit**, but the build
-reports them as **2-bit / 8-bit**, so the expr parser rejects every `xreg`/`xxreg`
-subfield reference and northd flow generation breaks. The symbols are registered
-in `lib/logical-fields.c` (`expr_symtab_add_field(symtab, xxname, MFF_XXREG0 + xxi, ...)`)
-from the OVS `mf_fields[]` meta-flow table — the wrong width points at an
-enum/array-index or struct-width miscomputation of `MFF_XXREG*`/`MFF_XREG*` on
-MSVC. Same integer-handling family as bug #2.
+`xxreg0` is **128-bit** and `xreg*` are **64-bit**, but they were reported as
+**2-/8-bit**, so the expr parser rejected the subfields and northd flow
+generation broke (~16 direct failures plus cascades).
+
+**Corrected root cause — not MSVC.** A prior in-source autotools build of the
+OVS submodule had left stale generated `ovs/lib/*.inc` (`meta-flow.inc`, …) on
+disk. A quoted `#include "meta-flow.inc"` from `ovs/lib/meta-flow.c` resolves the
+compiland's own directory before any `-I` path, so the stale in-source copy
+shadowed the freshly generated `gen/lib/meta-flow.inc`. The stale table had 183
+field entries against today's 211-id `MFF_N_IDS`; with positional initialization
++ direct indexing (`mf_fields[id]`), every field whose enum position had shifted
+read the wrong slot, so `xxreg`/`xreg` landed on small fields and reported
+2-/8-bit. (OVN's `lib/logical-fields.c` registration was correct all along.)
+
+These `.inc` are `.gitignore`'d generated artifacts, so a **clean checkout (CI)
+was never affected** — this only bites a local tree that was once
+autotools-built. Fixed by removing the stale in-source `.inc`; a configure-time
+guard in the OVS CMake (`file(REMOVE …)`, dbosoft/ovs) prevents recurrence and
+reaches OVN on the next `ovs` submodule bump. Confirmed: after the removal +
+rebuild, `ovntest test-ovn parse-expr` normalizes `xxreg0[0..127]` → `xxreg0`
+and accepts `xxreg0[64..127]` with no error.
 
 ## 2. `ovn-nbctl` mirror `Index/Key` integer bug
 
@@ -46,6 +59,7 @@ MSVC integer-width/sign-extension bug.
 ## Still to triage
 
 ~37 failures (mostly `ovn-macros.at:992`/`:944` and `ovs-macros.at:221` macro
-"hard failure"s) are not yet individually root-caused. Most are expected to be
-downstream of bug #1 (northd producing wrong/incomplete southbound data); they
-should be re-checked once the `xxreg` width bug is fixed.
+"hard failure"s) were attributed to bug #1 (northd producing wrong/incomplete
+southbound data from the corrupted register widths). With #1 resolved, **the
+baseline must be re-measured on a clean build** — these cascades are expected to
+clear. Re-baseline before individually triaging any remainder.


### PR DESCRIPTION
`known-failures.md` attributed the `xxreg`/`xreg` "2-/8-bit field" failure to an MSVC enum/width miscomputation. That diagnosis was wrong.

**Real root cause:** a prior in-source autotools build of the `ovs` submodule left a stale generated `ovs/lib/meta-flow.inc` on disk. A quoted `#include "meta-flow.inc"` from `ovs/lib/meta-flow.c` resolves the compiland's own directory before any `-I` path, so the stale copy shadowed the freshly generated `gen/lib/meta-flow.inc`. The stale table had 183 field entries vs today's 211-id `MFF_N_IDS`; with positional init + direct indexing (`mf_fields[id]`), the register fields read the wrong slots and reported 2-/8-bit instead of 128/64-bit. OVN's `lib/logical-fields.c` was correct all along.

A clean checkout (CI) never had the stale `.inc`, so CI was unaffected — this only bites a local tree that was once autotools-built. Confirmed fixed after removing it: `ovntest test-ovn parse-expr` normalizes `xxreg0[0..127]` → `xxreg0` and accepts `xxreg0[64..127]` with no error. A configure-time guard in dbosoft/ovs (PR dbosoft/ovs#51) prevents recurrence and reaches OVN on the next `ovs` submodule bump.

Doc-only: corrects the section-1 root cause, flags that the local 304/65 baseline was contaminated and must be re-measured on a clean build, and notes the ~37 cascades are expected to clear. Bug #2 (mirror Index/Key) is untouched.